### PR TITLE
updated kotlin_version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.30'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
The kotlin version included in build.gradle was outdated and caused build issues when trying to deploy to android. This PR should fix that issue.